### PR TITLE
XProcSpec tests for `text-to-ssml`

### DIFF
--- a/text-to-ssml/src/main/resources/xml/xproc/styled-text-to-ssml.xpl
+++ b/text-to-ssml/src/main/resources/xml/xproc/styled-text-to-ssml.xpl
@@ -80,9 +80,16 @@
     <p:iteration-source select="//ssml:lexicon[@uri]">
       <p:pipe port="ssml-of-lexicons-uris" step="main"/>
     </p:iteration-source>
+    <p:variable name="ssml-uri" select="p:base-uri(/*)">
+      <p:pipe port="ssml-of-lexicons-uris" step="main"/>
+    </p:variable>
+    <p:variable name="lexicon-uri" select="resolve-uri(*/@uri, $ssml-uri)"/>
     <p:load>
-      <p:with-option name="href" select="*/@uri"/>
+      <p:with-option name="href" select="$lexicon-uri"/>
     </p:load>
+    <px:message>
+      <p:with-option name="message" select="concat('loaded lexicon: ', $lexicon-uri)"/>
+    </px:message>
   </p:for-each>
 
   <!-- iterate over the fileset to extract the lexicons URI, then load them -->

--- a/text-to-ssml/src/test/resources/lexicon-test-en.pls
+++ b/text-to-ssml/src/test/resources/lexicon-test-en.pls
@@ -1,0 +1,48 @@
+<lexicon version="1.0"
+      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon
+        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
+      alphabet="ipa" xml:lang="en">
+
+  <!-- regular substitutions -->
+  <lexeme>
+    <grapheme>grapheme1en</grapheme>
+    <phoneme>phoneme1en</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>grapheme2en</grapheme>
+    <phoneme>phoneme2en</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>grapheme3en</grapheme>
+    <alias>alias3en</alias>
+  </lexeme>
+
+  <!-- substitutions with look-aheads -->
+  <lexeme>
+    <grapheme positive-lookahead="[ ]+test">before1</grapheme>
+    <phoneme>before1phoneme</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme positive-lookahead="[ ]+test">before2</grapheme>
+    <alias>before2alias</alias>
+  </lexeme>
+
+  <!-- regex without look-ahead -->
+  <lexeme regex="true">
+    <grapheme>([0-9]+)</grapheme>
+    <alias>k$1</alias>
+  </lexeme>
+
+  <lexeme regex="true">
+    <grapheme>([A-Z]+)</grapheme>
+    <phoneme>regphoneme</phoneme>
+  </lexeme>
+
+  <!-- regex with look-aheads -->
+  <lexeme regex="true">
+    <grapheme positive-lookahead="[ ]+test">a</grapheme>
+    <alias>b</alias>
+  </lexeme>
+</lexicon>

--- a/text-to-ssml/src/test/resources/lexicon-test-fr.pls
+++ b/text-to-ssml/src/test/resources/lexicon-test-fr.pls
@@ -1,0 +1,15 @@
+<lexicon version="1.0"
+      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon
+        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
+      xml:lang="fr">
+  <lexeme>
+    <grapheme>grapheme1fr</grapheme>
+    <phoneme alphabet="ipa">phoneme1fr</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>grapheme2fr</grapheme>
+    <phoneme alphabet="ipa">phoneme2fr</phoneme>
+  </lexeme>
+</lexicon>

--- a/text-to-ssml/src/test/xprocspec/clean-text.xpl
+++ b/text-to-ssml/src/test/xprocspec/clean-text.xpl
@@ -1,0 +1,28 @@
+<p:declare-step version="1.0" type="pxi:clean-text"  xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+    xmlns:p="http://www.w3.org/ns/xproc" exclude-inline-prefixes="#all">
+
+  <p:input port="source" primary="true"/>
+  <p:output port="result" primary="true"/>
+
+  <p:xslt>
+    <p:input port="parameters">
+      <p:empty/>
+    </p:input>
+    <p:input port="stylesheet">
+      <p:inline>
+	<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+			version="2.0">
+	  <xsl:template match="text()" priority="2">
+	    <xsl:value-of select="replace(., '[^a-zA-Z0-9]', '')"/>
+	  </xsl:template>
+	  <xsl:template match="@*|node()" priority="1">
+	    <xsl:copy>
+	      <xsl:apply-templates select="@*|node()"/>
+	    </xsl:copy>
+	  </xsl:template>
+	</xsl:stylesheet>
+      </p:inline>
+    </p:input>
+  </p:xslt>
+
+</p:declare-step>

--- a/text-to-ssml/src/test/xprocspec/extract-skippable.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/extract-skippable.xprocspec
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+               script="../../main/resources/xml/xslt/extract-skippable.xsl">
+
+
+  <x:script>
+    <p:declare-step version="1.0"
+  		    xmlns:p="http://www.w3.org/ns/xproc"
+  		    type="pxi:extract-skippable-wrapper">
+
+      <p:input port="source" primary="true"/>
+      <p:output port="result" primary="true"/>
+      <p:xslt name="xslt">
+  	<p:with-param name="skippable-elements" select="'pagenum,noteref'"/>
+  	<p:input port="stylesheet">
+  	  <p:document href="../../main/resources/xml/xslt/extract-skippable.xsl"/>
+  	</p:input>
+      </p:xslt>
+      <p:wrap-sequence wrapper="ssml:root">
+  	<p:input port="source">
+  	  <p:pipe port="result" step="xslt"/>
+  	  <p:pipe port="secondary" step="xslt"/>
+  	</p:input>
+      </p:wrap-sequence>
+    </p:declare-step>
+  </x:script>
+
+
+
+  <x:scenario label="one skippable type, one mark">
+    <x:call step="pxi:extract-skippable-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left">left</span><pagenum id="pnum">1</pagenum><span id="right">right</span>
+	    </ssml:s>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:root>
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left">left</span><ssml:mark name="left___right"/><span id="right">right</span>
+	    </ssml:s>
+	  </dtbook>
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left"></span><pagenum id="pnum">1</pagenum><span id="right"></span>
+	    </ssml:s>
+	  </dtbook>
+	</ssml:root>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="no element after">
+    <x:call step="pxi:extract-skippable-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left">left</span><pagenum id="pnum">1</pagenum>
+	    </ssml:s>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:root>
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left">left</span><ssml:mark name="left___"/>
+	    </ssml:s>
+	  </dtbook>
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left"></span><pagenum id="pnum">1</pagenum>
+	    </ssml:s>
+	  </dtbook>
+	</ssml:root>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+
+  <x:scenario label="one skippable type, two marks">
+    <x:call step="pxi:extract-skippable-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left1">left</span><pagenum id="pnum1">1</pagenum><span id="right1">right</span>
+	      <span id="left2">left</span><pagenum id="pnum2">2</pagenum><span id="right2">right</span>
+	    </ssml:s>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	 <ssml:root>
+	   <dtbook>
+	     <ssml:s id="s1">
+	       <span id="left1">left</span><ssml:mark name="left1___right1"/><span id="right1">right</span>
+	       <span id="left2">left</span><ssml:mark name="left2___right2"/><span id="right2">right</span>
+	     </ssml:s>
+	 </dtbook>
+	 <dtbook>
+	   <ssml:s id="s1">
+	     <span id="left1"/><pagenum id="pnum1">1</pagenum><span id="right1"/>
+	     <span id="left2"/><pagenum id="pnum2">2</pagenum><span id="right2"/>
+	   </ssml:s>
+	 </dtbook>
+	 </ssml:root>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="two skippable types, two marks">
+    <x:call step="pxi:extract-skippable-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <ssml:s id="s1">
+	      <span id="left1">left</span><pagenum id="pnum">1</pagenum><span id="right1">right</span>
+	      <span id="left2">left</span><noteref id="nref">1</noteref><span id="right2">right</span>
+	    </ssml:s>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	 <ssml:root>
+	   <dtbook>
+	     <ssml:s id="s1">
+	       <span id="left1">left</span><ssml:mark name="left1___right1"/><span id="right1">right</span>
+	       <span id="left2">left</span><ssml:mark name="left2___right2"/><span id="right2">right</span>
+	     </ssml:s>
+	   </dtbook>
+	   <dtbook>
+	     <ssml:s id="s1">
+	       <span id="left1"/><pagenum id="pnum">1</pagenum><span id="right1"/>
+	       <span id="left2"/><noteref id="nref">1</noteref><span id="right2"/>
+	     </ssml:s>
+	 </dtbook>
+	 </ssml:root>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/normalize.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/normalize.xprocspec
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+	       xmlns="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+	       xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	       xmlns:d="http://www.daisy.org/ns/pipeline/data"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+               script="../../main/resources/xml/xproc/styled-text-to-ssml.xpl">
+
+  <x:script>
+    <p:declare-step version="1.0" name="main"
+  		    xmlns:p="http://www.w3.org/ns/xproc"
+  		    type="pxi:normalize">
+
+      <p:input port="source" primary="true"/>
+      <p:output port="result" primary="true"/>
+      <p:option name="word-attr" select="''" required="false"/>
+      <p:option name="word-attr-val" select="''" required="false"/>
+      <p:xslt>
+	<p:with-param name="word-element" select="'w'"/>
+	<p:with-param name="word-attr" select="$word-attr"/>
+	<p:with-param name="word-attr-val" select="$word-attr-val"/>
+  	<p:input port="stylesheet">
+  	  <p:document href="../../main/resources/xml/xslt/normalize.xsl"/>
+  	</p:input>
+	<p:input port="source">
+	  <p:pipe port="source" step="main"/>
+	  <p:inline>
+	    <d:sentences>
+	      <d:s id="s1"/>
+	      <d:s id="s2"/>
+	      <d:s id="s3"/>
+	      <d:s id="s4"/>
+	      <d:s id="s5"/>
+	    </d:sentences>
+	  </p:inline>
+	</p:input>
+      </p:xslt>
+      <!-- It doesn't matter if token's attributes are kept or not: -->
+      <p:delete match="ssml:token/@*[namespace-uri() != 'http://www.daisy.org/ns/pipeline/tmp']"/>
+    </p:declare-step>
+  </x:script>
+
+  <x:scenario label="Regular sentence normalization">
+    <x:call step="pxi:normalize">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span id="s1">sentence1</span>
+	    <level>
+	      <span id="s2">sentence2</span>
+	    </level>
+	  </dtbook>
+	</x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="normalized" type="compare">
+      <x:document type="inline">
+	<dtbook>
+	  <ssml:s id="s1">sentence1</ssml:s>
+	  <level><ssml:s id="s2">sentence2</ssml:s></level>
+	</dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Regular word normalization">
+    <x:call step="pxi:normalize">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span id="s1"><w>word1</w> <w>word2</w></span>
+	  </dtbook>
+	</x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="normalized" type="compare">
+      <x:document type="inline">
+	<dtbook><ssml:s id="s1"><ssml:token>word1</ssml:token> <ssml:token>word2</ssml:token></ssml:s></dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Attribute-dependent Word normalization">
+    <x:call step="pxi:normalize">
+      <x:option name="word-attr" select="'attr'"/>
+      <x:option name="word-attr-val" select="'right'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span id="s1"><w>word1</w> <w attr="wrong">word2</w> <w attr="right">word3</w></span>
+	  </dtbook>
+	</x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="normalized" type="compare">
+      <x:document type="inline">
+	<dtbook><ssml:s id="s1"><w>word1</w> <w attr="wrong">word2</w> <ssml:token>word3</ssml:token></ssml:s></dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+
+  <x:scenario label="Keep CSS attributes on sentences">
+    <x:call step="pxi:normalize">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span id="s1" tmp:volume="3">sentence</span>
+	  </dtbook>
+	</x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="normalized" type="compare">
+      <x:document type="inline">
+	<dtbook><ssml:s id="s1" tmp:volume="3">sentence</ssml:s></dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Keep CSS attributes on words">
+    <x:call step="pxi:normalize">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span id="s1"><w tmp:volume="3">word</w></span>
+	  </dtbook>
+	</x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="normalized" type="compare">
+      <x:document type="inline">
+	<dtbook><ssml:s id="s1"><ssml:token tmp:volume="3">word</ssml:token></ssml:s></dtbook>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/pls-to-ssml.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/pls-to-ssml.xprocspec
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns:dt="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+               script="text-to-ssml-wrapper.xpl">
+
+  <x:scenario label="English substitutions">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><token>grapheme1en</token></s>
+	    <s id="s2"><token>grapheme3en</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><token>
+	      <phoneme alphabet="ipa" ph="phoneme1en">grapheme1en</phoneme>
+	    </token></s>
+	    <s id="s2" xml:lang="en"><token>aliask3en</token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="French substitution">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="fr">
+	    <s id="s1"><token>grapheme1fr</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="fr"><token>
+	      <phoneme alphabet="ipa" ph="phoneme1fr">grapheme1fr</phoneme>
+	    </token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Look-aheads">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><token>before1</token>, </s>
+	    <s id="s2"><token>before1</token> <token>test</token></s>
+	    <s id="s3"><token>before2</token>, </s>
+	    <s id="s4"><token>before2</token> <token>test</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><token>beforek1</token></s>
+	    <s id="s2" xml:lang="en"><token>
+	      <phoneme alphabet="ipa" ph="before1phoneme">before1</phoneme>
+	    </token><token>test</token></s>
+	    <s id="s3" xml:lang="en"><token>beforek2</token></s>
+	    <s id="s4" xml:lang="en"><token>beforek2alias</token><token>test</token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/punctuation.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/punctuation.xprocspec
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+	       xmlns="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+	       xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	       xmlns:d="http://www.daisy.org/ns/pipeline/data"
+               script="../../main/resources/xml/xproc/styled-text-to-ssml.xpl">
+
+  <x:scenario label="Capture the punctuation marks">
+    <x:call step="px:styled-text-to-ssml">
+      <x:input port="fileset.in">
+	<x:empty/>
+      </x:input>
+    <x:input port="ssml-of-lexicons-uris">
+      <x:empty/>
+    </x:input>
+    <x:option name="section-elements" select="'level,section'"/>
+    <x:option name="style-ns" select="'http://tmp/'"/>
+    <x:input port="content.in">
+      <x:document type="inline">
+	<dtbook xml:lang="en">
+	  <ssml:s id="s1">First test</ssml:s>?
+	  <ssml:s id="s2">Second test</ssml:s> ?
+	  <ssml:s id="s3">Third test</ssml:s><span/> ?
+	  <ssml:s id="s4">Fourth test</ssml:s>
+	</dtbook>
+      </x:document>
+    </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:speak version="1.1">
+	  <ssml:s xml:lang="en" id="s1">First test?</ssml:s>
+	  <ssml:s xml:lang="en" id="s2">Second test?</ssml:s>
+	  <ssml:s xml:lang="en" id="s3">Third test?</ssml:s>
+	  <ssml:s xml:lang="en" id="s4">Fourth test.</ssml:s>
+	</ssml:speak>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/regex-pls-to-ssml.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/regex-pls-to-ssml.xprocspec
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns:dt="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+               script="text-to-ssml-wrapper.xpl">
+
+  <x:scenario label="Basic regex alias">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><token>a47</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><token>ak47</token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Basic regex phoneme">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><token>ABCD</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><token><phoneme ph="regphoneme">ABCD</phoneme></token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Look ahead">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="with-lexicons" select="'true'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><token>baaab</token> <token>test</token></s>
+	    <s id="s2"><token>baaab</token> <token>wronglookahead</token></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><token>bbbbb</token><token>test</token></s>
+	    <s id="s2" xml:lang="en"><token>baaab</token><token>wronglookahead</token></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/skippable-to-ssml.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/skippable-to-ssml.xprocspec
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+	       xmlns:xml="http://www.w3.org/XML/1998/namespace"
+               script="../../main/resources/xml/skippable-to-ssml.xpl">
+
+
+  <x:script>
+    <p:declare-step version="1.0"
+		    xmlns:p="http://www.w3.org/ns/xproc"
+		    xmlns:d="http://www.daisy.org/ns/pipeline/data"
+		    type="pxi:skippable-to-ssml-wrapper">
+
+      <p:import href="../../main/resources/xml/skippable-to-ssml.xpl"/>
+      <p:import href="../../main/resources/xml/clean-text.xpl"/>
+
+      <p:input port="source" primary="true"/>
+      <p:output port="result" primary="true"/>
+
+      <pxi:skippable-to-ssml>
+	<p:with-option name="skippable-elements" select="'pagenum,noteref'"/>
+	<p:with-option name="style-ns" select="'http://www.daisy.org/ns/pipeline/tmp'"/>
+      </pxi:skippable-to-ssml>
+
+      <p:wrap-sequence wrapper="all" wrapper-namespace="http://www.w3.org/2001/10/synthesis"/>
+      <pxi:clean-text/>
+    </p:declare-step>
+  </x:script>
+
+  <x:scenario label="One skippable">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <pagenum id="p1">1</pagenum>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx"><ssml:mark name="___p1"/>1<ssml:mark name="p1___"/></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Skippable only">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <span>text</span>
+	    <pagenum id="p1">1</pagenum>
+	    <span>text</span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx"><ssml:mark name="___p1"/>1<ssml:mark name="p1___"/></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Two separate skippables">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <pagenum xml:lang="xx" id="p1">1</pagenum>
+	    <pagenum xml:lang="yy" id="p2">2</pagenum>
+	    <span>text</span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx"><ssml:mark name="___p1"/>1<ssml:mark name="p1___"/></ssml:s>
+	  </ssml:speak>
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p2" xml:lang="yy"><ssml:mark name="___p2"/>2<ssml:mark name="p2___"/></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Internationalization">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="en">
+	    <noteref id="n1">1</noteref>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-n1" xml:lang="en"><ssml:mark name="___n1"/>note1<ssml:mark name="n1___"/></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+    <x:scenario label="Internationalization (empty content)">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="en">
+	    <noteref id="n1"/>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-n1" xml:lang="en"><ssml:mark name="___n1"/>cf. note<ssml:mark name="n1___"/></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Single CSS projection">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <span tmp:volume="30">
+	      <pagenum id="p1">1</pagenum>
+	    </span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx"><ssml:prosody volume="30"><ssml:mark name="___p1"/>1<ssml:mark name="p1___"/></ssml:prosody></ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Double CSS projection">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <span tmp:speech-rate="10">
+	      <span tmp:volume="30">
+		<pagenum id="p1">1</pagenum>
+	      </span>
+	    </span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx">
+	      <ssml:prosody volume="30">
+		<ssml:prosody rate="10">
+		  <ssml:mark name="___p1"/>1<ssml:mark name="p1___"/>
+		</ssml:prosody>
+	      </ssml:prosody>
+	    </ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Grouping">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook xml:lang="xx">
+	    <span tmp:speech-rate="30">
+	      <span tmp:volume="30" tmp:speech-rate="10">
+		<pagenum id="p1">1</pagenum>
+	      </span>
+	    </span>
+	    <span tmp:speech-rate="10">
+	      <pagenum id="p2">2</pagenum>
+	    </span>
+	    <span tmp:volume="30" tmp:speech-rate="10">
+	      <pagenum id="p3">3</pagenum>
+	    </span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx">
+	      <ssml:prosody volume="30">
+		<ssml:prosody rate="10">
+		  <ssml:mark name="___p1"/>1<ssml:mark name="p1___"/>
+		  <ssml:mark name="___p3"/>3<ssml:mark name="p3___"/>
+		</ssml:prosody>
+	      </ssml:prosody>
+	    </ssml:s>
+	  </ssml:speak>
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p2" xml:lang="xx">
+	      <ssml:prosody rate="10">
+		<ssml:mark name="___p2"/>2<ssml:mark name="p2___"/>
+	      </ssml:prosody>
+	    </ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Grouping with language">
+    <x:call step="pxi:skippable-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dtbook>
+	    <span tmp:volume="30" xml:lang="xx">
+	      <pagenum id="p1">1</pagenum>
+	    </span>
+	    <span tmp:volume="30" xml:lang="yy">
+	      <pagenum id="p2">2</pagenum>
+	    </span>
+	    <span tmp:volume="30" xml:lang="xx">
+	      <pagenum id="p3">3</pagenum>
+	    </span>
+	  </dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="skippable-free" type="compare">
+      <x:document type="inline">
+	<ssml:all xmlns="http://www.w3.org/2001/10/synthesis">
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p1" xml:lang="xx">
+	      <ssml:prosody volume="30">
+		<ssml:mark name="___p1"/>1<ssml:mark name="p1___"/>
+		<ssml:mark name="___p3"/>3<ssml:mark name="p3___"/>
+	      </ssml:prosody>
+	    </ssml:s>
+	  </ssml:speak>
+	  <ssml:speak version="1.1">
+	    <ssml:s id="cousins-of-p2" xml:lang="yy">
+	      <ssml:prosody volume="30">
+		<ssml:mark name="___p2"/>2<ssml:mark name="p2___"/>
+	      </ssml:prosody>
+	    </ssml:s>
+	  </ssml:speak>
+	</ssml:all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+
+</x:description>

--- a/text-to-ssml/src/test/xprocspec/text-to-ssml-wrapper.xpl
+++ b/text-to-ssml/src/test/xprocspec/text-to-ssml-wrapper.xpl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step version="1.0"
+    xmlns:p="http://www.w3.org/ns/xproc"
+    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+    xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+    xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+    name="main" exclude-inline-prefixes="#all"
+    type="pxi:text-to-ssml-wrapper">
+
+  <p:import href="../../main/resources/xml/xproc/styled-text-to-ssml.xpl"/>
+  <p:import href="clean-text.xpl"/>
+
+  <p:input port="source" primary="true"/>
+  <p:output port="result" primary="true"/>
+
+  <p:option name="with-lexicons" required="false" select="'false'"/>
+  <p:option name="sheet-uri" required="false" select="''"/>
+
+  <p:choose name="lexicons-uris">
+    <p:when test="$with-lexicons = 'true'">
+      <p:output port="result"/>
+      <p:identity>
+	<p:input port="source">
+	  <p:inline>
+	    <ssml:speak version="1.0"
+			xmlns="http://www.w3.org/2001/10/synthesis"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xsi:schemaLocation="http://www.w3.org/2001/10/synthesis
+					    http://www.w3.org/TR/speech-synthesis/synthesis.xsd">
+	      <ssml:lexicon uri="../resources/lexicon-test-en.pls"/>
+	      <ssml:lexicon uri="../resources/lexicon-test-fr.pls"/>
+	    </ssml:speak>
+	  </p:inline>
+	</p:input>
+      </p:identity>
+    </p:when>
+    <p:otherwise>
+      <p:output port="result">
+	<p:empty/>
+      </p:output>
+      <p:sink/>
+    </p:otherwise>
+  </p:choose>
+
+  <px:styled-text-to-ssml>
+    <p:input port="content.in">
+      <p:pipe port="source" step="main"/>
+    </p:input>
+    <p:input port="fileset.in">
+      <p:empty/>
+    </p:input>
+    <p:input port="ssml-of-lexicons-uris">
+      <p:pipe port="result" step="lexicons-uris"/>
+    </p:input>
+    <p:with-option name="section-elements" select="'level,section'"/>
+    <p:with-option name="first-sheet-uri" select="$sheet-uri"/>
+    <p:with-option name="style-ns" select="'http://www.daisy.org/ns/pipeline/tmp'"/>
+  </px:styled-text-to-ssml>
+
+  <p:wrap-sequence wrapper="all" wrapper-namespace="http://www.w3.org/2001/10/synthesis"/>
+
+  <!-- Clean the text nodes because the conversion to SSML may add punctuation marks and white spaces. -->
+  <pxi:clean-text/>
+</p:declare-step>

--- a/text-to-ssml/src/test/xprocspec/text-to-ssml.xprocspec
+++ b/text-to-ssml/src/test/xprocspec/text-to-ssml.xprocspec
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+	       xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"
+	       xmlns:dt="http://www.daisy.org/z3986/2005/dtbook/"
+	       xmlns="http://www.w3.org/2001/10/synthesis"
+	       xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
+               script="text-to-ssml-wrapper.xpl">
+
+  <x:scenario label="basic transformation">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    abc<dt:level><s id="s1">xzy</s></dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">xzy</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Same level">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s id="s1">sentence1</s>
+	      <s id="s2">sentence2</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">sentence1</s>
+	    <s id="s2" xml:lang="en">sentence2</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Two levels">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s id="s1">sentence1</s>
+	    </dt:level>
+	    <dt:level>
+	      <s id="s2">sentence2</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">sentence1</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s2" xml:lang="en">sentence2</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Between levels">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s id="s1">sentence1</s>
+	    </dt:level>
+	    <s id="s2">sentence2</s>
+	    <dt:level>
+	      <s id="s3">sentence3</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">sentence1</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s2" xml:lang="en">sentence2</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s3" xml:lang="en">sentence3</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Nested levels">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <dt:level>
+		<s id="s1">sentence1</s>
+	      </dt:level>
+	      <s id="s2">sentence2</s>
+	    </dt:level>
+	    <dt:level>
+	      <s id="s3">sentence3</s>
+	      <dt:level>
+		<s id="s4">sentence4</s>
+		<dt:level>
+		  <s id="s5">sentence5</s>
+		</dt:level>
+	      </dt:level>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">sentence1</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s2" xml:lang="en">sentence2</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s3" xml:lang="en">sentence3</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s4" xml:lang="en">sentence4</s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s5" xml:lang="en">sentence5</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Language settings">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level xml:lang="fr">
+	      <s id="s1">sentence</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="fr">sentence</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="CSS properties outside sentences">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en" tmp:pitch="1">
+	    <dt:level tmp:volume="2" tmp:speech-rate="3">
+	      <dt:span tmp:pitch="0">
+		<s id="s1">sentence</s>
+	      </dt:span>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <!-- Order should not matter but it makes the comparison simpler. -->
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      <prosody volume="2">
+		<prosody pitch="0">
+		  <prosody rate="3">
+		    sentence
+		  </prosody>
+		</prosody>
+	      </prosody>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="CSS properties inside sentences">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1">word1<dt:span tmp:speech-rate="0" tmp:volume="1"><dt:span tmp:pitch="2" tmp:speech-rate="3">word2</dt:span></dt:span></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      word1
+	      <prosody volume="1">
+		<prosody rate="0">
+		  <prosody pitch="2">
+		    <prosody rate="3">
+		      word2
+		    </prosody>
+		  </prosody>
+		</prosody>
+	      </prosody>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Mixed CSS properties">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en" tmp:volume="1">
+	    <s id="s1">word1<dt:span><dt:span tmp:volume="2">word2</dt:span></dt:span></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      <prosody volume="1">
+		word1
+		<prosody volume="2">
+		  word2
+		</prosody>
+	      </prosody>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="Pre-existent inside SSML">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1"><prosody volume="1">sentence</prosody></s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      <prosody volume="1">sentence</prosody>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <!-- Not implemented yet. It seems to be only allowed in ZedAI documents. -->
+  <!-- <x:scenario label="Pre-existent outside SSML"> -->
+  <!--   <x:call step="pxi:text-to-ssml-wrapper"> -->
+  <!--     <x:input port="source"> -->
+  <!-- 	<x:document type="inline"> -->
+  <!-- 	  <dt:dtbook xml:lang="en"> -->
+  <!-- 	    <prosody volume="1"><s id="s1">sentence</s></prosody> -->
+  <!-- 	  </dt:dtbook> -->
+  <!--       </x:document> -->
+  <!--     </x:input> -->
+  <!--   </x:call> -->
+  <!--   <x:context label="result"> -->
+  <!--     <x:document type="port" port="result"/> -->
+  <!--   </x:context> -->
+  <!--   <x:expect label="result" type="compare"> -->
+  <!--     <x:document type="inline"> -->
+  <!-- 	<all> -->
+  <!-- 	  <speak version="1.1"> -->
+  <!-- 	    <s id="s1" xml:lang="en"> -->
+  <!-- 	      <prosody volume="1">sentence</prosody> -->
+  <!-- 	    </s> -->
+  <!-- 	  </speak> -->
+  <!-- 	</all> -->
+  <!--     </x:document> -->
+  <!--   </x:expect> -->
+  <!-- </x:scenario> -->
+
+  <x:scenario label="SSML tokens">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <s id="s1" xml:lang="en">
+	      <token>word1</token> <token>word2</token>
+	    </s>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      <token>word1</token> <token>word2</token>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="voice-family">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s tmp:voice-family="espeak" id="s1">sentence1</s>
+	      <s tmp:voice-family="att,alain16" id="s2">sentence2</s>
+	      <s tmp:voice-family="att,16" id="s3">sentence3</s>
+	      <s tmp:voice-family="16,male,att" id="s4">sentence4</s>
+	      <s tmp:voice-family="female,15" id="s5">sentence5</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en" voice-selector1="espeak">sentence1</s>
+	    <s id="s2" xml:lang="en" voice-selector1="att" voice-selector2="alain16">sentence2</s>
+	    <s id="s3" xml:lang="en" voice-selector1="att" voice-age="16">sentence3</s>
+	    <s id="s4" xml:lang="en" voice-selector1="att" voice-age="16" voice-gender="male">sentence4</s>
+	    <s id="s5" xml:lang="en" voice-age="15" voice-gender="female">sentence5</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="say-as">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s tmp:speak='spell-out' id="s1">sentence1</s>
+	      <s tmp:speak-numeral='digits' id="s2">sentence2</s>
+	      <s tmp:speak-numeral='continuous' id="s3">sentence3</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><say-as interpret-as="characters">sentence1</say-as></s>
+	    <s id="s2" xml:lang="en"><say-as interpret-as="ordinal">sentence2</say-as></s>
+	    <s id="s3" xml:lang="en"><say-as interpret-as="cardinal">sentence3</say-as></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="simple pause">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level tmp:pause-before='10'>
+	      <s id="s1">sentence</s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en"><break time="10"/>sentence</s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="inner pause">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level>
+	      <s id="s1"><dt:span tmp:pause-after="10">sentence</dt:span></s>
+	    </dt:level>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">sentence<break time="10"/></s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="mixed pauses and cues">
+    <x:call step="pxi:text-to-ssml-wrapper">
+      <x:option name="sheet-uri" select="'file:///foo/bar/test.css'"/>
+      <x:input port="source">
+	<x:document type="inline">
+	  <dt:dtbook xml:lang="en">
+	    <dt:level tmp:pause-before="1" tmp:pause-after="2">
+	      <dt:level tmp:cue-after="beep1.mp3"/>
+	    </dt:level>
+	    <dt:level tmp:pause-before="3" tmp:cue-before="beep2.mp3" tmp:pause-after="6">
+	      <dt:level tmp:pause-before="4" tmp:pause-after="5">
+	    	<s id="s1">sentence1</s>
+	      </dt:level>
+	      <s id="s2">sentence2</s>
+	    </dt:level>
+	    <dt:level tmp:cue-after="beep3.mp3" tmp:pause-after="7"/>
+	  </dt:dtbook>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+	<all>
+	  <speak version="1.1">
+	    <s id="s1" xml:lang="en">
+	      <break time="1"/>
+	      <audio src="/foo/bar/beep1.mp3"/>
+	      <break time="2"/>
+	      <break time="3"/>
+	      <audio src="/foo/bar/beep2.mp3"/>
+	      <break time="4"/>sentence1<break time="5"/>
+	    </s>
+	  </speak>
+	  <speak version="1.1">
+	    <s id="s2" xml:lang="en">
+	      sentence2
+	      <break time="6"/>
+	      <break time="7"/>
+	      <audio src="/foo/bar/beep3.mp3"/>
+	    </s>
+	  </speak>
+	</all>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+</x:description>


### PR DESCRIPTION
- Made it possible for users to use relative URIs in the list of lexicons.
