### PR TITLE
New option to prevent name conflicts when creating the audio file set

### DIFF
--- a/ssml-to-audio/src/main/resources/xml/create-audio-fileset.xpl
+++ b/ssml-to-audio/src/main/resources/xml/create-audio-fileset.xpl
@@ -4,26 +4,31 @@
 		xmlns:d="http://www.daisy.org/ns/pipeline/data">
 
   <p:input port="source" primary="true" /> <!-- audio clips -->
-  <p:output port="fileset.out" sequence="false" primary="true"/>  <!-- fileset of audio files -->
+  <p:output port="fileset.out" sequence="false" primary="true">  <!-- fileset of audio files -->
+    <p:pipe port="result" step="fileset.result"/>
+  </p:output>
+  <p:output port="result" sequence="false">  <!-- modified audio map if $anti-conflict-prefix is provided -->
+    <p:pipe port="result" step="new-audio-map"/>
+  </p:output>
 
   <p:option name="output-dir" required="true"/>
   <p:option name="audio-relative-dir" required="true"/>
-  
+  <p:option name="anti-conflict-prefix" required="false" select="''"/>
+
   <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
-  
+
   <p:variable name="audio-dir" select="concat($output-dir, $audio-relative-dir)">
     <p:empty/>
   </p:variable>
 
-  <!-- Iterate over the resulting SMIL files to add them to a new fileset. -->
-  <!-- Add the sound files to the fileset as well. -->
+  <!-- Iterate over the sound clips of the audio-map. -->
   <p:for-each name="for-each-audio">
     <!-- identical audio files should be adjacent in the clip list -->
     <p:iteration-source select="//d:clip[not(preceding::d:clip[1]) or (@src != preceding::d:clip[1]/@src)]"/>
     <p:variable name="former-src" select="/*/@src">
       <p:pipe port="current" step="for-each-audio"/>
     </p:variable>
-    <p:variable name="new-src" select="concat($audio-dir, tokenize($former-src, '[\\/]+')[last()])"/>
+    <p:variable name="new-src" select="concat($audio-dir, $anti-conflict-prefix, tokenize($former-src, '[\\/]+')[last()])"/>
     <px:fileset-create/>
     <!-- TODO: deal with other format than audio/mpeg -->
     <px:fileset-add-entry first="true" media-type="audio/mpeg">
@@ -31,6 +36,14 @@
       <p:with-option name="original-href" select="$former-src" />
     </px:fileset-add-entry>
   </p:for-each>
-  <px:fileset-join/>
+  <px:fileset-join name="fileset.result"/>
+
+  <p:string-replace match="@src" name="new-audio-map">
+    <p:input port="source">
+      <p:pipe port="source" step="main"/>
+    </p:input>
+    <p:with-option name="replace"
+		   select="concat('replace(., ''/([^/]+)$'', ''/', $anti-conflict-prefix, '$1'')')"/>
+  </p:string-replace>
 
 </p:declare-step>


### PR DESCRIPTION
Add an option to the XPRoc step of the creation of audio the fileset to prevent name conflicting regarding the audio files
