### PR TITLE
Delete the generated audio directory when the JVM exits gracefully

### DIFF
--- a/ssml-to-audio/src/main/java/org/daisy/pipeline/tts/synthesize/SynthesizeStep.java
+++ b/ssml-to-audio/src/main/java/org/daisy/pipeline/tts/synthesize/SynthesizeStep.java
@@ -159,6 +159,7 @@ public class SynthesizeStep extends DefaultStep implements FormatSpecifications,
 			audioOutputDir = new File(audioDir);
 		} while (audioOutputDir.exists());
 		audioOutputDir.mkdir();
+		audioOutputDir.deleteOnExit();
 
 		SSMLtoAudio ssmltoaudio = new SSMLtoAudio(audioOutputDir, mTTSRegistry, this,
 		        mAudioBufferTracker, mRuntime.getProcessor(), mURIresolver, cr, log);


### PR DESCRIPTION
- Not that useful since it won't work when the JVM is killed, but it's better than nothing.