### PR TITLE
mod-tts: updated dependencies

### DIFF
--- a/css-speech/src/main/resources/META-INF/catalog.xml
+++ b/css-speech/src/main/resources/META-INF/catalog.xml
@@ -4,6 +4,4 @@
   <uri name="http://www.daisy.org/pipeline/modules/css-speech/library.xpl"
        uri="../xml/library.xpl"/>
 
-  <nextCatalog catalog="org:daisy:pipeline:modules:css-utils" />
-
 </catalog>

--- a/dtbook-tts/src/main/resources/xml/tts-for-dtbook.xpl
+++ b/dtbook-tts/src/main/resources/xml/tts-for-dtbook.xpl
@@ -67,6 +67,7 @@
   <p:import href="http://www.daisy.org/pipeline/modules/ssml-to-audio/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/dtbook-to-ssml/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/dtbook-break-detection/library.xpl"/>
+  <p:import href="http://www.daisy.org/pipeline/modules/css-speech/library.xpl"/>
 
   <!-- Find the sentences and the words, even if the Text-To-Speech is off. -->
   <p:for-each name="lexing">

--- a/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
+++ b/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
@@ -107,6 +107,7 @@
   <p:import href="http://www.daisy.org/pipeline/modules/epub3-to-ssml/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/html-break-detection/library.xpl"/>
   <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
+  <p:import href="http://www.daisy.org/pipeline/modules/css-speech/library.xpl"/>
 
   <p:variable name="fileset-base" select="base-uri(/*)">
     <p:pipe port="fileset.in" step="main"/>

--- a/ssml-to-audio/src/main/resources/META-INF/catalog.xml
+++ b/ssml-to-audio/src/main/resources/META-INF/catalog.xml
@@ -4,7 +4,6 @@
   <uri name="http://www.daisy.org/pipeline/modules/ssml-to-audio/library.xpl"
        uri="../xml/library.xpl"/>
 
-  <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils" />
 
 </catalog>

--- a/tts-utils/tts-common/src/main/resources/META-INF/catalog.xml
+++ b/tts-utils/tts-common/src/main/resources/META-INF/catalog.xml
@@ -3,5 +3,7 @@
 
   <uri name="http://www.daisy.org/pipeline/modules/tts-common/library.xpl"
        uri="../xml/library.xpl"/>
+  
+  <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
 
 </catalog>


### PR DESCRIPTION
I did a quick scan through and removed unused module dependencies and added missing module dependencies from the XML catalogs.

see also (can be merged separately):
daisy/pipeline-modules-common#80
daisy/pipeline-scripts-utils#75
daisy/pipeline-scripts#83
daisy/pipeline-mod-braille#14
daisy/pipeline-mod-tts#52

<!---
@huboard:{"order":104.0,"milestone_order":461.75,"custom_state":""}
-->
