### PR TITLE
don't use severity=INFO for messages in tts-utils

### DIFF
--- a/tts-utils/tts-common/src/main/resources/xml/get-config-annotations.xpl
+++ b/tts-utils/tts-common/src/main/resources/xml/get-config-annotations.xpl
@@ -22,7 +22,7 @@
     <p:load name="load">
       <p:with-option name="href" select="resolve-uri($href, base-uri(/*))"/>
     </p:load>
-    <px:message>
+    <px:message severity="DEBUG">
       <p:with-option name="message" select="concat($href, ' loaded')"/>
     </px:message>
   </p:for-each>


### PR DESCRIPTION
see also (can be merged separately):
daisy/pipeline-modules-common#81
daisy/pipeline-scripts-utils#76
daisy/pipeline-mod-tts#53

<!---
@huboard:{"order":103.0,"milestone_order":53,"custom_state":""}
-->
