### PR TITLE
Modified xpath to avoid internal saxon error

### DIFF
--- a/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
+++ b/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
@@ -107,6 +107,7 @@
   <p:import href="http://www.daisy.org/pipeline/modules/epub3-to-ssml/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/html-break-detection/library.xpl"/>
   <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
+  <p:import href="http://www.daisy.org/pipeline/modules/css-speech/library.xpl"/>
 
   <p:variable name="fileset-base" select="base-uri(/*)">
     <p:pipe port="fileset.in" step="main"/>

--- a/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
+++ b/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
@@ -127,7 +127,7 @@
       <p:xpath-context>
 	<p:pipe port="fileset.in" step="main"/>
       </p:xpath-context>
-      <p:when test="//*[@media-type='application/xhtml+xml' and resolve-uri(@href, $fileset-base)=$doc-uri]">
+      <p:when test="//*[@media-type='application/xhtml+xml']/resolve-uri(@href, $fileset-base)=$doc-uri">
 	<p:output port="html">
 	  <p:pipe port="result" step="id"/>
 	</p:output>


### PR DESCRIPTION
The error reads:

```
*** Internal Saxon error: local variable encountered whose binding has been deleted
```

This seems to be the same old error as encountered in this thread:

https://lists.w3.org/Archives/Public/xproc-dev/2011Dec/0010.html

...so the error probably only occurs when using oXygen with Saxon EE, not when running Pipeline 2.

<!---
@huboard:{"order":101.0,"milestone_order":64,"custom_state":""}
-->
