### PR TITLE
Various changes related to XProcSpec testing

### DIFF
--- a/css-speech/pom.xml
+++ b/css-speech/pom.xml
@@ -45,18 +45,43 @@
       <artifactId>tts-helpers</artifactId>
     </dependency>
     <dependency>
-     <groupId>junit</groupId>
-     <artifactId>junit</artifactId>
-     <scope>test</scope>
-   </dependency>
-   <dependency>
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-api</artifactId>
-   </dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <!--
+        test dependencies
+    -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.pipeline</groupId>
+      <artifactId>framework-volatile</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.pipeline.build</groupId>
+      <artifactId>modules-test-helper</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>maven-paxexam-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-depends-file</id>
+            <goals>
+              <goal>generate-depends-file</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -67,9 +92,18 @@
               *
             </Import-Package>
             <Service-Component>OSGI-INF/inline-css.xml</Service-Component>
-	    <Export-Package/>
+            <Export-Package/>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-before-test</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/css-speech/src/main/resources/xml/inline-css-speech.xpl
+++ b/css-speech/src/main/resources/xml/inline-css-speech.xpl
@@ -23,7 +23,9 @@
   <p:import href="inline-css.xpl"/>
   <p:import href="clean-up-namespaces.xpl"/>
 
-  <p:variable name="style-ns" select="'http://www.daisy.org/ns/pipeline/tts'"/>
+  <p:variable name="style-ns" select="'http://www.daisy.org/ns/pipeline/tts'">
+	<p:empty/>
+  </p:variable>
 
   <p:for-each name="loop">
     <p:output port="result" sequence="true"/>

--- a/css-speech/src/test/java/XProcSpecTest.java
+++ b/css-speech/src/test/java/XProcSpecTest.java
@@ -1,0 +1,14 @@
+import org.daisy.pipeline.junit.AbstractXSpecAndXProcSpecTest;
+
+public class XProcSpecTest extends AbstractXSpecAndXProcSpecTest {
+	
+	@Override
+	protected String[] testDependencies() {
+		return new String[] {
+			"org.daisy.libs:jstyleparser:?",
+			"commons-io:commons-io:?",
+			"org.daisy.pipeline:calabash-adapter:?",
+			"org.daisy.pipeline.modules:tts-helpers:?",
+		};
+	}
+}

--- a/css-speech/src/test/resources/logback.xml
+++ b/css-speech/src/test/resources/logback.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+   
+  <appender name="TEST_LOG" class="ch.qos.logback.core.FileAppender">
+    <file>target/test.log</file>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  
+  <root level="WARN">
+    <appender-ref ref="TEST_LOG"/>
+  </root>
+  
+  <logger name="org.daisy" level="DEBUG"/>
+  <logger name="cz.vutbr.web" level="WARN"/>
+  
+</configuration>

--- a/css-speech/src/test/xprocspec/test_inline-css-speech.xprocspec
+++ b/css-speech/src/test/xprocspec/test_inline-css-speech.xprocspec
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+               xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+               xmlns:d="http://www.daisy.org/ns/pipeline/data"
+               xmlns:tts="http://www.daisy.org/ns/pipeline/tts"
+               script="../../main/resources/xml/inline-css-speech.xpl">
+  
+  <x:scenario label="config">
+    <x:call step="px:inline-css-speech">
+      <x:input port="source">
+        <x:document type="inline" xml:base="file:/tmp/dtbook.xml">
+          <dtbook>
+            <book>
+              <div>
+                <p/>
+              </div>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:input port="fileset.in">
+        <x:document type="inline">
+          <d:fileset>
+            <d:file href="file:/tmp/dtbook.xml" media-type="application/x-dtbook+xml"/>
+          </d:fileset>
+        </x:document>
+      </x:input>
+      <x:input port="config">
+        <x:document type="inline">
+          <config>
+            <css href="../resources/test.css"/>
+          </config>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result" select="//book"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+        <book>
+          <div>
+            <p tts:speech-rate="10"/>
+          </div>
+        </book>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+  
+  <x:scenario label="config inline">
+    <x:call step="px:inline-css-speech">
+      <x:input port="source">
+        <x:document type="inline" xml:base="file:/tmp/dtbook.xml">
+          <dtbook>
+            <book>
+              <div>
+                <p/>
+              </div>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:input port="fileset.in">
+        <x:document type="inline">
+          <d:fileset>
+            <d:file href="file:/tmp/dtbook.xml" media-type="application/x-dtbook+xml"/>
+          </d:fileset>
+        </x:document>
+      </x:input>
+      <x:input port="config">
+        <x:document type="inline">
+          <config>
+            <css>
+              p {
+                voice-family: female;
+              }
+            </css>
+          </config>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result" select="//book"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+        <book>
+          <div>
+            <p tts:voice-family="female"/>
+          </div>
+        </book>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+  
+  <x:scenario label="link">
+    <x:call step="px:inline-css-speech">
+      <x:input port="source">
+        <x:document type="inline">
+          <dtbook>
+            <head>
+              <link rel="stylesheet" type="text/css" href="../resources/test.css"/>
+            </head>
+            <book>
+              <div>
+                <p tts:speech-rate="10"/>
+              </div>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:input port="fileset.in">
+        <x:document type="inline">
+          <d:fileset>
+            <d:file href="test_inline-css-speech.xprocspec" media-type="application/x-dtbook+xml"/>
+          </d:fileset>
+        </x:document>
+      </x:input>
+      <x:input port="config">
+        <x:document type="inline">
+          <config/>
+        </x:document>
+      </x:input>
+    </x:call>
+    <x:context label="result">
+      <x:document type="port" port="result" select="//book"/>
+    </x:context>
+    <x:expect label="result" type="compare">
+      <x:document type="inline">
+        <book>
+          <div>
+            <p tts:speech-rate="10"/>
+          </div>
+        </book>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+  
+</x:description>

--- a/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
+++ b/epub3-tts/src/main/resources/xml/tts-for-epub3.xpl
@@ -107,6 +107,13 @@
     </p:documentation>
   </p:option>
 
+  <p:option name="temp-dir" select="''">
+    <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+      <p>Empty directory dedicated to this conversion. May be left empty in which case a temporary
+      directory will be automaticall created.</p>
+    </p:documentation>
+  </p:option>
+
   <p:import href="http://www.daisy.org/pipeline/modules/ssml-to-audio/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/epub3-to-ssml/library.xpl" />
   <p:import href="http://www.daisy.org/pipeline/modules/html-break-detection/library.xpl"/>
@@ -230,6 +237,9 @@
 	  <p:pipe port="config" step="main"/>
 	</p:input>
 	<p:with-option name="output-dir" select="$output-dir">
+	  <p:empty/>
+	</p:with-option>
+	<p:with-option name="temp-dir" select="if ($temp-dir!='') then concat($temp-dir,'audio/') else ''">
 	  <p:empty/>
 	</p:with-option>
       </px:ssml-to-audio>

--- a/ssml-to-audio/src/main/resources/xml/ssml-to-audio.xpl
+++ b/ssml-to-audio/src/main/resources/xml/ssml-to-audio.xpl
@@ -10,6 +10,12 @@
     <p:pipe step="synthesize" port="status"/>
   </p:output>
   <p:option name="output-dir" select="''"/>
+  <p:option name="temp-dir" select="''">
+    <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+      <p>If not empty, this directory will be used to store audio files. The directory must not
+      exist yet. Overrides the global <code>org.daisy.pipeline.tts.audio.tmpdir</code> setting.</p>
+    </p:documentation>
+  </p:option>
 
   <p:import href="synthesize.xpl" />
 
@@ -18,6 +24,9 @@
       <p:pipe port="config" step="main"/>
     </p:input>
     <p:with-option name="output-dir" select="$output-dir">
+      <p:empty/>
+    </p:with-option>
+    <p:with-option name="temp-dir" select="$temp-dir">
       <p:empty/>
     </p:with-option>
   </px:synthesize>

--- a/ssml-to-audio/src/main/resources/xml/synthesize.xpl
+++ b/ssml-to-audio/src/main/resources/xml/synthesize.xpl
@@ -18,5 +18,6 @@
         </p:documentation>
     </p:output>
     <p:option name="output-dir"/>
+    <p:option name="temp-dir"/>
 
 </p:declare-step>


### PR DESCRIPTION
- Test px:inline-css-speech
- Add option to set location of temporary audio files in px:ssml-to-audio in order to make fileset output of px:dtbook-to-epub3 testable (see also https://github.com/daisy/pipeline-scripts/pull/151).